### PR TITLE
adds travis ci tests + fix failing tests for PackageSyncWorkerTest + …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: elixir
+elixir:
+  - 1.1.0
+otp_release:
+  - 17.4
+addons:
+  postgresql: "9.4"
+sudo: false # to use faster container based build environment
+env:
+  - ELIXIR_ERL_OPTIONS=""
+  - ELIXIR_ERL_OPTIONS="+T 9"
+script:
+  - mix deps.get
+  - mix test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # The BEAM Toolbox
 
+[![Build Status](https://secure.travis-ci.org/henrik/toolbox.svg?branch=master
+"Build Status")](https://travis-ci.org/henrik/toolbox)
+
 <http://toolbox.elixir.pm>
 
 A site to list Hex packages by category.

--- a/test/lib/toolbox/package_sync_worker_test.exs
+++ b/test/lib/toolbox/package_sync_worker_test.exs
@@ -22,16 +22,16 @@ defmodule Toolbox.PackageSyncWorkerTest do
     Process.register self, :test
     {:ok, _} = Toolbox.PackageSyncWorker.start_link
 
-    :timer.sleep 20
+    :timer.sleep 15
     refute_received :synced
 
-    :timer.sleep 10
+    :timer.sleep 15
     assert_received :synced
 
-    :timer.sleep 20
+    :timer.sleep 15
     refute_received :synced
 
-    :timer.sleep 10
+    :timer.sleep 15
     assert_received :synced
   end
 end


### PR DESCRIPTION
…status badge in readme

Problem:
- PackageSyncWorkerTest is failing when running with "+T 9" ERLANG option (it influences the behaviour of the Erlang scheduler)

Solution:
- just decrease the waiting time for refuting the :synced signal from 20 to 15
- not sure it this a "proper" solution, but it works reliably

See https://travis-ci.org/mindreframer/toolbox/builds/93421933 where this failure occured. 

Closes https://github.com/henrik/toolbox/issues/11
